### PR TITLE
Remove requests and bump aiohttp

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,8 +13,7 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 dependencies = [
-  'requests==2.28.1',
-  'aiohttp==3.8.1',
+  'aiohttp==3.8.4',
 ]
 
 [project.urls]

--- a/src/pyytlounge/manual_pairing.py
+++ b/src/pyytlounge/manual_pairing.py
@@ -1,8 +1,12 @@
 #!/usr/bin/env python
 
-import requests
+import asyncio
+import aiohttp
 from api import api_base
-
+async def get_screen(pairing_code):
+    async with aiohttp.ClientSession() as session:
+        async with session.post(f"{api_base}/pairing/get_screen", data={'pairing_code': pairing_code}) as response:
+            return await response.json()
 pairing_code = input("Enter manual pairing code as shown in YouTube app on target: ")
 try:
     pairing_code = int(pairing_code)
@@ -10,8 +14,9 @@ except Exception as ex:
     print(f"Invalid pairing code {pairing_code}", ex)
 
 # initial paring with code
-res = requests.post(f"{api_base}/pairing/get_screen", data={'pairing_code': pairing_code})
-screens = res.json()
+loop = asyncio.get_event_loop()
+
+screens = loop.run_until_complete(get_screen(pairing_code))
 screen = screens["screen"]
 screen_name = screen["name"]
 screen_id = screen["screenId"]


### PR DESCRIPTION
This PR completely removes the need for requests, and bumps the aiohttp version to the latest one, 3.8.4