### PR TITLE
Update connect()

### DIFF
--- a/src/pyytlounge/wrapper.py
+++ b/src/pyytlounge/wrapper.py
@@ -383,7 +383,7 @@ class YtLoungeApi:
             "capabilities": "que,dsdtr,atp",
             "method": "setPlaylist",
             "magnaKey": "cloudPairedDevice",
-            "ui": "",
+            "ui": "false",
             "deviceContext": "user_agent=dunno&window_width_points=&window_height_points=&os_name=android&ms=",
             "theme": "cl",
             "loungeIdToken": self.auth.lounge_id_token,


### PR DESCRIPTION
Set ui to false, which makes it not prompt to change accounts while running YouTubeTVKids. It's very weird, but it works.
Without this flag, YouTube kids couldn't be used while connected.
Should fix: https://github.com/dmunozv04/iSponsorBlockTV/issues/84