### PR TITLE
Add vsp capability

### DIFF
--- a/src/pyytlounge/wrapper.py
+++ b/src/pyytlounge/wrapper.py
@@ -259,7 +259,7 @@ class YtLoungeApi:
             "name": self.device_name,
             "id": self.auth.screen_id,
             "device": "REMOTE_CONTROL",
-            "capabilities": "que,dsdtr,atp",
+            "capabilities": "que,dsdtr,atp,vsp",
             "method": "setPlaylist",
             "magnaKey": "cloudPairedDevice",
             "ui": "false",


### PR DESCRIPTION
Adds `vsp` capability, which allows receiving `playbackSpeed` events. 
Could be useful to have a second PR that adds playbackSpeed to`PlaybackState` so downstream packages can use it 