### PR TITLE
feat: Add closed captions

### DIFF
--- a/src/pyytlounge/__init__.py
+++ b/src/pyytlounge/__init__.py
@@ -1,4 +1,4 @@
-from .wrapper import YtLoungeApi, get_thumbnail_url
+from .wrapper import YtLoungeApi, get_thumbnail_url, get_available_captions
 from .event_listener import EventListener
 from .events import (
     PlaybackStateEvent,

--- a/src/pyytlounge/api.py
+++ b/src/pyytlounge/api.py
@@ -1,6 +1,34 @@
+import aiohttp
+
 api_base = "https://www.youtube.com/api/lounge"
 
 
 def get_thumbnail_url(video_id: str, thumbnail_idx=0) -> str:
     """Returns thumbnail for given video. Use thumbnail idx to get different thumbnails."""
     return f"https://img.youtube.com/vi/{video_id}/{thumbnail_idx}.jpg"
+
+
+async def get_available_captions(api_key: str, video_id: str):
+    """Uses the traditional YouTube API to enumerate available subtitle tracks."""
+    yt_base_url = "https://www.googleapis.com/youtube/v3/captions"
+    params = {
+        "part": "snippet",
+        "videoId": video_id,
+        "key": api_key
+    }
+
+    async with aiohttp.ClientSession() as session:
+        async with session.get(yt_base_url, params=params) as response:
+            if response.status != 200:
+                raise Exception(f"Request failed with status {response.status}")
+            
+            data = await response.json()
+            
+            languages = []
+            for item in data.get("items", []):
+                snippet = item.get("snippet", {})
+                language = snippet.get("language")
+                if language and language not in languages:
+                    languages.append(language)
+                    
+            return languages

--- a/src/pyytlounge/wrapper.py
+++ b/src/pyytlounge/wrapper.py
@@ -6,10 +6,10 @@ import logging
 from typing import Any, AsyncIterator, Dict, List, Optional
 
 import aiohttp
-from aiohttp import ClientTimeout, ClientPayloadError, ClientSession
+from aiohttp import ClientTimeout, ClientPayloadError
 
 from .api import api_base
-from .api import get_thumbnail_url  # noqa # we want to export this from this module
+from .api import get_thumbnail_url, get_available_captions  # noqa # we want to export this from this module
 from .event_listener import EventListener, _EmptyListener
 from .events import (
     PlaybackStateEvent,
@@ -466,28 +466,3 @@ class YtLoungeApi:
         """
         lang = language_code if language_code is not None else ""
         return await self._command("setSubtitlesTrack", {"languageCode": lang, "videoId": video_id})
-    
-    async def get_available_captions(self, api_key: str, video_id: str):
-        """Uses the traditional YouTube API to enumerate available subtitle tracks."""
-        yt_base_url = "https://www.googleapis.com/youtube/v3/captions"
-        params = {
-            "part": "snippet",
-            "videoId": video_id,
-            "key": api_key
-        }
-
-        async with aiohttp.ClientSession() as session:
-            async with session.get(yt_base_url, params=params) as response:
-                if response.status != 200:
-                    raise Exception(f"Request failed with status {response.status}")
-                
-                data = await response.json()
-                
-                languages = []
-                for item in data.get("items", []):
-                    snippet = item.get("snippet", {})
-                    language = snippet.get("language")
-                    if language and language not in languages:
-                        languages.append(language)
-                        
-                return languages

--- a/src/pyytlounge/wrapper.py
+++ b/src/pyytlounge/wrapper.py
@@ -6,7 +6,7 @@ import logging
 from typing import Any, AsyncIterator, Dict, List, Optional
 
 import aiohttp
-from aiohttp import ClientTimeout, ClientPayloadError
+from aiohttp import ClientTimeout, ClientPayloadError, ClientSession
 
 from .api import api_base
 from .api import get_thumbnail_url  # noqa # we want to export this from this module
@@ -465,3 +465,28 @@ class YtLoungeApi:
         video_id is always required.
         """
         return await self._command("setSubtitlesTrack", {"languageCode": language_code, "videoId": video_id})
+    
+    async def get_available_captions(self, api_key: str, video_id: str):
+        """Uses the traditional YouTube API to enumerate available subtitle tracks."""
+        yt_base_url = "https://www.googleapis.com/youtube/v3/captions"
+        params = {
+            "part": "snippet",
+            "videoId": video_id,
+            "key": api_key
+        }
+
+        async with aiohttp.ClientSession() as session:
+            async with session.get(yt_base_url, params=params) as response:
+                if response.status != 200:
+                    raise Exception(f"Request failed with status {response.status}")
+                
+                data = await response.json()
+                
+                languages = []
+                for item in data.get("items", []):
+                    snippet = item.get("snippet", {})
+                    language = snippet.get("language")
+                    if language and language not in languages:
+                        languages.append(language)
+                        
+                return languages

--- a/src/pyytlounge/wrapper.py
+++ b/src/pyytlounge/wrapper.py
@@ -457,3 +457,11 @@ class YtLoungeApi:
     async def send_dpad_command(self, button_input: DpadCommand) -> bool:
         """Sends a dpad command like a remote."""
         return await self._command("dpadCommand", {"key": button_input})
+
+    async def set_closed_captions(self, language_code: str | None, video_id: str):
+        """
+        Sets the closed captions to the provided BCP-47 language_code if available.
+        Provide the language_code as None to toggle closed captions to off.
+        video_id is always required.
+        """
+        return await self._command("setSubtitlesTrack", {"languageCode": language_code, "videoId": video_id})

--- a/src/pyytlounge/wrapper.py
+++ b/src/pyytlounge/wrapper.py
@@ -458,7 +458,7 @@ class YtLoungeApi:
         """Sends a dpad command like a remote."""
         return await self._command("dpadCommand", {"key": button_input})
 
-    async def set_closed_captions(self, language_code: str | None, video_id: str):
+    async def set_closed_captions(self, language_code: Optional[str], video_id: str):
         """
         Sets the closed captions to the provided BCP-47 language_code if available.
         Provide the language_code as None to toggle closed captions to off.

--- a/src/pyytlounge/wrapper.py
+++ b/src/pyytlounge/wrapper.py
@@ -464,7 +464,8 @@ class YtLoungeApi:
         Provide the language_code as None to toggle closed captions to off.
         video_id is always required.
         """
-        return await self._command("setSubtitlesTrack", {"languageCode": language_code, "videoId": video_id})
+        lang = language_code if language_code is not None else ""
+        return await self._command("setSubtitlesTrack", {"languageCode": lang, "videoId": video_id})
     
     async def get_available_captions(self, api_key: str, video_id: str):
         """Uses the traditional YouTube API to enumerate available subtitle tracks."""


### PR DESCRIPTION
Closes #8.  Adds two functions:
- set_closed_captions(language_code, video_id): provide a language code, and captions will be set to that language.  Provide None for language code, and captions will be turned off.  Video ID is always required.
- get_available_captions(api_key, video_id): returns an array of all available language codes to provide to set_closed_captions.  Requires an API key from https://console.cloud.google.com/apis/credentials

I think get_available_captions could lives somewhere besides the Lounge wrapper, since it's not really using the Lounge API, but I couldn't find a good place elsewhere - maybe we can address that in the future.