### PR TITLE
Add support for new event types

### DIFF
--- a/src/pyytlounge/event_listener.py
+++ b/src/pyytlounge/event_listener.py
@@ -5,6 +5,11 @@ from .events import (
     PlaybackStateEvent,
     VolumeChangedEvent,
     AutoplayModeChangedEvent,
+    AdStateEvent,
+    AdPlayingEvent,
+    SubtitlesTrackEvent,
+    AutoplayUpNextEvent,
+    PlaybackSpeedEvent,
 )
 
 
@@ -26,6 +31,21 @@ class EventListener(ABC):
 
     async def autoplay_changed(self, event: AutoplayModeChangedEvent) -> None:
         """Called when auto play mode changes"""
+
+    async def ad_state_changed(self, event: AdStateEvent) -> None:
+        """Called when ad state changes (position, play/pause, skippable)"""
+
+    async def ad_playing_changed(self, event: AdPlayingEvent) -> None:
+        """Called when ad starts playing"""
+
+    async def subtitles_track_changed(self, event: SubtitlesTrackEvent) -> None:
+        """Called when subtitles track changes"""
+
+    async def autoplay_up_next_changed(self, event: AutoplayUpNextEvent) -> None:
+        """Called when up next video changes"""
+
+    async def playback_speed_changed(self, event: PlaybackSpeedEvent) -> None:
+        """Called when playback speed changes"""
 
     async def disconnected(self) -> None:
         """Called when the screen is no longer connected"""

--- a/src/pyytlounge/events.py
+++ b/src/pyytlounge/events.py
@@ -7,6 +7,11 @@ from .lounge_models import (
     _PlaybackStateData,
     _VolumeChangedData,
     _AutoplayModeChangedData,
+    _AdStateData,
+    _AdPlayingData,
+    _SubtitlesTrackData,
+    _AutoplayUpNextData,
+    _PlaybackSpeedData,
 )
 
 _logger = logging.getLogger(__name__)
@@ -52,3 +57,60 @@ class AutoplayModeChangedEvent:
     def __init__(self, data: _AutoplayModeChangedData):
         self.enabled: bool = data["autoplayMode"] == "ENABLED"
         self.supported: bool = data["autoplayMode"] != "UNSUPPORTED"
+
+
+class AdStateEvent:
+    """Contains information related to ad state"""
+
+    def __init__(self, data: _AdStateData):
+        self.ad_state = State.parse(data["adState"])
+        self.current_time: float = float(data["currentTime"])
+        self.is_skip_enabled: bool = data["isSkipEnabled"] == "true"
+
+class AdPlayingEvent:
+    """Contains information related to ad state"""
+
+    def __init__(self, data: _AdPlayingData):
+        self.ad_video_id: str | None = data.get("adVideoId", None)
+        self.ad_video_uri: str | None = data.get("adVideoUri", None)
+        self.ad_title: str = data["adTitle"]
+        self.is_bumper: bool = data["isBumper"] == "true"
+        self.is_skippable: bool = data["isSkippable"] == "true"
+        self.is_skip_enabled: bool = data["isSkipEnabled"] == "true"
+        self.click_through_url: str = data["clickThroughUrl"]
+        self.ad_system: str = data["adSystem"]
+        self.ad_next_params: str = data["adNextParams"]
+        self.remote_slots_data: str | None = data.get("remoteSlotsData", None)
+        self.ad_state = State.parse(data["adState"])
+        self.content_video_id: str = data["contentVideoId"]
+        self.duration: float = float(data["duration"])
+        self.current_time: float = float(data["currentTime"])
+
+
+class SubtitlesTrackEvent:
+    """Contains information related to subtitles track"""
+
+    def __init__(self, data: _SubtitlesTrackData):
+        self.video_id: str = data["videoId"]
+        self.track_name: str | None = data.get("trackName", None)
+        self.language_code: str | None = data.get("languageCode", None)
+        self.source_language_code: str | None = data.get("sourceLanguageCode", None)
+        self.language_name: str | None = data.get("languageName", None)
+        self.kind: str | None = data.get("kind", None)
+        self.vss_id: str | None = data.get("vss_id", None)
+        self.caption_id: str | None = data.get("captionId", None)
+        self.style: str | None = data.get("style", None)
+
+
+class AutoplayUpNextEvent:
+    """Contains information related the next video to be played"""
+
+    def __init__(self, data: _AutoplayUpNextData):
+        self.video_id: str = data["videoId"]
+
+
+class PlaybackSpeedEvent:
+    """Contains information related to playback speed"""
+
+    def __init__(self, data: _PlaybackSpeedData):
+        self.playback_speed: float = data["playbackSpeed"]

--- a/src/pyytlounge/lounge_models.py
+++ b/src/pyytlounge/lounge_models.py
@@ -39,3 +39,43 @@ class _Device(TypedDict):
 
 class _LoungeStatus(TypedDict):
     devices: str  # json string containing list of __Device
+
+
+class _AdStateData(TypedDict):
+    adState: str
+    currentTime: str
+    isSkipEnabled: str
+
+
+class _AdPlayingData(_AdStateData):
+    adVideoId: str
+    adVideoUri: str
+    adTitle: str
+    isBumper: str
+    isSkippable: str
+    clickThroughUrl: str
+    adSystem: str
+    adNextParams: str
+    remoteSlotsData: str
+    contentVideoId: str
+    duration: str
+
+
+class _SubtitlesTrackData(TypedDict):
+    videoId: str
+    trackName: str
+    languageCode: str
+    sourceLanguageCode: str
+    languageName: str
+    kind: str
+    vss_id: str
+    captionId: str
+    style: str
+
+
+class _AutoplayUpNextData(TypedDict):
+    videoId: str
+
+
+class _PlaybackSpeedData(TypedDict):
+    playbackSpeed: str

--- a/src/pyytlounge/wrapper.py
+++ b/src/pyytlounge/wrapper.py
@@ -193,19 +193,14 @@ class YtLoungeApi:
             await self.event_listener.autoplay_changed(AutoplayModeChangedEvent(args[0]))
         elif event_type == "onAdStateChange":
             await self.event_listener.ad_state_changed(AdStateEvent(args[0]))
-            pass
         elif event_type == "adPlaying":
             await self.event_listener.ad_playing_changed(AdPlayingEvent(args[0]))
-            pass
         elif event_type == "onSubtitlesTrackChanged":
             await self.event_listener.subtitles_track_changed(SubtitlesTrackEvent(args[0]))
-            pass
-        elif event_type == "autoplayUpNext":
+        elif event_type == "autoplayUpNext" and args:
             await self.event_listener.autoplay_up_next_changed(AutoplayUpNextEvent(args[0]))
-            pass
         elif event_type == "onPlaybackSpeedChanged":
             await self.event_listener.playback_speed_changed(PlaybackSpeedEvent(args[0]))
-            pass
         elif event_type == "loungeStatus":
             data: _LoungeStatus = args[0]
             devices: List[_Device] = json.loads(data["devices"])

--- a/src/pyytlounge/wrapper.py
+++ b/src/pyytlounge/wrapper.py
@@ -16,6 +16,11 @@ from .events import (
     NowPlayingEvent,
     VolumeChangedEvent,
     AutoplayModeChangedEvent,
+    AdStateEvent,
+    AdPlayingEvent,
+    SubtitlesTrackEvent,
+    AutoplayUpNextEvent,
+    PlaybackSpeedEvent,
 )
 from .models import AuthState, DpadCommand
 from .lounge_models import _Device, _DeviceInfo, _LoungeStatus
@@ -186,6 +191,21 @@ class YtLoungeApi:
             await self.event_listener.volume_changed(VolumeChangedEvent(args[0]))
         elif event_type == "onAutoplayModeChanged":
             await self.event_listener.autoplay_changed(AutoplayModeChangedEvent(args[0]))
+        elif event_type == "onAdStateChange":
+            await self.event_listener.ad_state_changed(AdStateEvent(args[0]))
+            pass
+        elif event_type == "adPlaying":
+            await self.event_listener.ad_playing_changed(AdPlayingEvent(args[0]))
+            pass
+        elif event_type == "onSubtitlesTrackChanged":
+            await self.event_listener.subtitles_track_changed(SubtitlesTrackEvent(args[0]))
+            pass
+        elif event_type == "autoplayUpNext":
+            await self.event_listener.autoplay_up_next_changed(AutoplayUpNextEvent(args[0]))
+            pass
+        elif event_type == "onPlaybackSpeedChanged":
+            await self.event_listener.playback_speed_changed(PlaybackSpeedEvent(args[0]))
+            pass
         elif event_type == "loungeStatus":
             data: _LoungeStatus = args[0]
             devices: List[_Device] = json.loads(data["devices"])


### PR DESCRIPTION
This PR adds support for: onAdStateChange, adPlaying, onSubtitlesTrackChanged, autoplayUpNext, onPlaybackSpeedChanged (they're used in iSponsorBlockTV)

The data fields on `lounge_models.py` have been taken from YouTube TV's javascript source code directly. 
Some events like `adPlaying` have lots of fields that maybe aren't that useful, idk if they should be included or not. 

Please do let me know if anything needs to be changed.

Thanks for your work on v3 of the library!