### PR TITLE
Add reason to disconnected event

### DIFF
--- a/src/pyytlounge/event_listener.py
+++ b/src/pyytlounge/event_listener.py
@@ -10,6 +10,7 @@ from .events import (
     SubtitlesTrackEvent,
     AutoplayUpNextEvent,
     PlaybackSpeedEvent,
+    DisconnectedEvent,
 )
 
 
@@ -47,7 +48,7 @@ class EventListener(ABC):
     async def playback_speed_changed(self, event: PlaybackSpeedEvent) -> None:
         """Called when playback speed changes"""
 
-    async def disconnected(self) -> None:
+    async def disconnected(self, event: DisconnectedEvent) -> None:
         """Called when the screen is no longer connected"""
 
 

--- a/src/pyytlounge/events.py
+++ b/src/pyytlounge/events.py
@@ -13,6 +13,7 @@ from .lounge_models import (
     _SubtitlesTrackData,
     _AutoplayUpNextData,
     _PlaybackSpeedData,
+    _DisconnectedData,
 )
 
 _logger = logging.getLogger(__name__)
@@ -117,3 +118,10 @@ class PlaybackSpeedEvent:
 
     def __init__(self, data: _PlaybackSpeedData):
         self.playback_speed: float = float(data["playbackSpeed"])
+
+
+class DisconnectedEvent:
+    """Contains information related to disconnection"""
+    
+    def __init__(self, data: Optional[_DisconnectedData]):
+        self.reason: Optional[str] = data.get("reason", None) if data else None

--- a/src/pyytlounge/lounge_models.py
+++ b/src/pyytlounge/lounge_models.py
@@ -79,3 +79,7 @@ class _AutoplayUpNextData(TypedDict):
 
 class _PlaybackSpeedData(TypedDict):
     playbackSpeed: str
+
+
+class _DisconnectedData(TypedDict):
+    reason: str

--- a/src/pyytlounge/wrapper.py
+++ b/src/pyytlounge/wrapper.py
@@ -214,7 +214,7 @@ class YtLoungeApi:
                     self._device_info = json.loads(device.get("deviceInfo", "null"))
                     break
         elif event_type == "loungeScreenDisconnected":
-            await self.event_listener.disconnected(DisconnectedEvent(args or None))
+            await self.event_listener.disconnected(DisconnectedEvent(args[0] if args else None))
             self._connection_lost()
             self._lounge_token_expired()
         elif event_type == "noop":

--- a/src/pyytlounge/wrapper.py
+++ b/src/pyytlounge/wrapper.py
@@ -21,6 +21,7 @@ from .events import (
     SubtitlesTrackEvent,
     AutoplayUpNextEvent,
     PlaybackSpeedEvent,
+    DisconnectedEvent
 )
 from .models import AuthState, DpadCommand
 from .lounge_models import _Device, _DeviceInfo, _LoungeStatus
@@ -213,7 +214,7 @@ class YtLoungeApi:
                     self._device_info = json.loads(device.get("deviceInfo", "null"))
                     break
         elif event_type == "loungeScreenDisconnected":
-            await self.event_listener.disconnected()
+            await self.event_listener.disconnected(DisconnectedEvent(args or None))
             self._connection_lost()
             self._lounge_token_expired()
         elif event_type == "noop":


### PR DESCRIPTION
Adds an optional reason field to the disconnect event. 
Since this adds an additional parameter to a event listener function, this is a breaking change
Fixes #21