### PR TITLE
Raise NotSupportedException

### DIFF
--- a/src/pyytlounge/exceptions.py
+++ b/src/pyytlounge/exceptions.py
@@ -17,3 +17,10 @@ class NotLinkedException(Exception):
     """This exception indicates an operation that failed due to an incorrect state.
     The operation requires that the API has been linked with a screen.
     Use the linked(), pair() and refresh_auth() functions on YtLoungeApi."""
+
+
+class NotSupportedException(Exception):
+    """This exception indicates an operation that failed due to connecting to an
+    unsupported client. Some YouTube clients (currently YouTube TV for Kids) are
+    not supported by this library and will raise this exception when attempting
+    to connect to them."""

--- a/src/pyytlounge/models.py
+++ b/src/pyytlounge/models.py
@@ -90,3 +90,6 @@ class DpadCommand(str, Enum):
     RIGHT = "RIGHT"
     ENTER = "ENTER"
     BACK = "BACK"
+
+
+blacklisted_clients = ["TVHTML5_FOR_KIDS"]

--- a/src/pyytlounge/models.py
+++ b/src/pyytlounge/models.py
@@ -92,4 +92,4 @@ class DpadCommand(str, Enum):
     BACK = "BACK"
 
 
-blacklisted_clients = ["TVHTML5_FOR_KIDS"]
+BLACKLISTED_CLIENTS = ["TVHTML5_FOR_KIDS"]

--- a/src/pyytlounge/wrapper.py
+++ b/src/pyytlounge/wrapper.py
@@ -22,7 +22,7 @@ from .events import (
     AutoplayUpNextEvent,
     PlaybackSpeedEvent,
 )
-from .models import AuthState, DpadCommand, blacklisted_clients
+from .models import AuthState, DpadCommand, BLACKLISTED_CLIENTS
 from .lounge_models import _Device, _DeviceInfo, _LoungeStatus
 from .exceptions import (
     NotConnectedException,
@@ -218,7 +218,7 @@ class YtLoungeApi:
                     self._device_info = json.loads(device.get("deviceInfo", "null"))
                     if (
                         self._device_info
-                        and self._device_info.get("clientName", "") in blacklisted_clients
+                        and self._device_info.get("clientName", "") in BLACKLISTED_CLIENTS
                     ):
                         raise NotSupportedException("Unsupported client")
                     break

--- a/src/pyytlounge/wrapper.py
+++ b/src/pyytlounge/wrapper.py
@@ -22,9 +22,14 @@ from .events import (
     AutoplayUpNextEvent,
     PlaybackSpeedEvent,
 )
-from .models import AuthState, DpadCommand
+from .models import AuthState, DpadCommand, blacklisted_clients
 from .lounge_models import _Device, _DeviceInfo, _LoungeStatus
-from .exceptions import NotConnectedException, NotLinkedException, NotPairedException
+from .exceptions import (
+    NotConnectedException,
+    NotLinkedException,
+    NotPairedException,
+    NotSupportedException,
+)
 from .util import as_aiter, iter_response_lines
 
 
@@ -211,6 +216,11 @@ class YtLoungeApi:
                 if device["type"] == "LOUNGE_SCREEN":
                     self._screen_name = device["name"]
                     self._device_info = json.loads(device.get("deviceInfo", "null"))
+                    if (
+                        self._device_info
+                        and self._device_info.get("clientName", "") in blacklisted_clients
+                    ):
+                        raise NotSupportedException("Unsupported client")
                     break
         elif event_type == "loungeScreenDisconnected":
             await self.event_listener.disconnected()


### PR DESCRIPTION
when connecting to an unsupported client
This currently only includes the `TVHTML5_FOR_KIDS` client

Feel free to change the variable names
(Fixes #20)